### PR TITLE
Removal of some old references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This app adds support for Z-wave devices made by [Samsung](https://www.samsungsd
 
 ## Links:
 [Samsung Locks Athom apps](https://apps.athom.com/app/com.samsung.lock)                    
-[MCOHome app Github repository](https://github.com/AutomateAsia/com.samsung.lock)   
+[Samsung Locks app Github repository](https://github.com/AutomateAsia/com.samsung.lock)   
 [Lock available on Automate Asia](https://h4sh.automate.asia/)   
 
 ## Supported devices:

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
 	"bugs": {
 		"url": "https://github.com/AutomateAsia/com.samsung.lock/issues"
 	},
-	"homepage": "https://forum.athom.com/discussion/3463/"
+	"homepage": "https://github.com/AutomateAsia/com.samsung.lock/"
 }


### PR DESCRIPTION
Just noticed some old references to MCO...

on the donation link, you might want to use the paypal.me option... saves the paypal fees